### PR TITLE
Fix bug in `array_handling.stack_by_init_date`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,10 +28,10 @@ dependencies:
   - brotlipy=0.7.0=py39h3811e60_1001
   - bzip2=1.0.8=h7f98852_4
   - c-ares=1.17.1=h7f98852_1
-  - ca-certificates=2021.5.30=ha878542_0
+  - ca-certificates=2021.10.8=ha878542_0
   - cairo=1.16.0=h6cf1ce9_1008
   - cartopy=0.19.0.post1=py39h3b23250_0
-  - certifi=2021.5.30=py39hf3d152e_0
+  - certifi=2021.10.8=py39hf3d152e_1
   - cf_xarray=0.5.2=pyh6c4a22f_0
   - cffi=1.14.5=py39he32792d_0
   - cfgrib=0.9.9.0=pyhd8ed1ab_1
@@ -101,6 +101,7 @@ dependencies:
   - importlib-metadata=4.5.0=py39hf3d152e_0
   - importlib_metadata=4.5.0=hd8ed1ab_0
   - importlib_resources=5.1.4=pyhd8ed1ab_0
+  - iniconfig=1.1.1=pyh9f0ad1d_0
   - ipykernel=5.5.5=py39hef51801_0
   - ipynbname=2021.3.2=pyhd8ed1ab_0
   - ipython=7.24.1=py39hef51801_0
@@ -186,6 +187,7 @@ dependencies:
   - matplotlib-inline=0.1.2=pyhd8ed1ab_2
   - mistune=0.8.4=py39h3811e60_1003
   - monotonic=1.5=py_0
+  - more-itertools=8.12.0=pyhd8ed1ab_0
   - msgpack-python=1.0.2=py39h1a9c180_1
   - multidict=5.1.0=py39h3811e60_1
   - munch=2.5.0=py_0
@@ -226,6 +228,7 @@ dependencies:
   - pint=0.17=pyhd8ed1ab_0
   - pip=21.1.2=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
+  - pluggy=1.0.0=py39hf3d152e_2
   - pooch=1.4.0=pyhd8ed1ab_0
   - poppler=0.89.0=h2de54a5_5
   - poppler-data=0.4.10=0
@@ -238,6 +241,7 @@ dependencies:
   - psutil=5.8.0=py39h3811e60_1
   - pthread-stubs=0.4=h36c2ea0_1001
   - ptyprocess=0.7.0=pyhd3deb0d_0
+  - py=1.11.0=pyh6c4a22f_0
   - pycparser=2.20=pyh9f0ad1d_2
   - pygeos=0.10=py39ha61afbd_0
   - pygments=2.9.0=pyhd8ed1ab_0
@@ -252,6 +256,7 @@ dependencies:
   - pyrsistent=0.17.3=py39h3811e60_2
   - pyshp=2.1.3=pyh44b312d_0
   - pysocks=1.7.1=py39hf3d152e_3
+  - pytest=6.2.5=py39hf3d152e_1
   - python=3.9.4=hffdb5ce_0_cpython
   - python-dateutil=2.8.1=py_0
   - python-eccodes=2021.03.0=py39hce5d2b2_1
@@ -290,6 +295,7 @@ dependencies:
   - threadpoolctl=2.1.0=pyh5ca1d4c_0
   - tiledb=2.2.9=h91fcb0e_0
   - tk=8.6.10=h21135ba_1
+  - toml=0.10.2=pyhd8ed1ab_0
   - toolz=0.11.1=py_0
   - tornado=6.1=py39h3811e60_1
   - traitlets=5.0.5=py_0
@@ -328,4 +334,3 @@ dependencies:
   - zipp=3.4.1=pyhd8ed1ab_0
   - zlib=1.2.11=h516909a_1010
   - zstd=1.4.9=ha95c52a_0
-

--- a/unseen/array_handling.py
+++ b/unseen/array_handling.py
@@ -16,7 +16,9 @@ def stack_by_init_date(ds, init_dates, n_lead_steps,
       ds (xarray Dataset)
       init_dates (list) : Initial dates in YYYY-MM-DD format
       n_lead_steps (int) : Maximum lead time
-      freq (str) : Time-step frequency
+      time_dim (str) : The name of the time dimension on ds
+      init_dim (str) : The name of the initial date dimension on the output array
+      lead_dim (str) : The name of the lead time dimension on the output array
       
     Note, only initial dates that fall within the time range of the input
     timeseries are retained. Thus, inital dates prior to the time range of
@@ -25,6 +27,7 @@ def stack_by_init_date(ds, init_dates, n_lead_steps,
     timeseries with nans so that the initial dates in question are present
     in the time dimension of the input timeseries.
     """
+    
     # Only keep init dates that fall within available times
     times = ds[time_dim]  
     init_dates = init_dates[np.logical_and(init_dates>=times.min(), init_dates<=times.max())]

--- a/unseen/array_handling.py
+++ b/unseen/array_handling.py
@@ -5,7 +5,7 @@ import pdb
 import numpy as np
 import xarray as xr
 
-import time_utils
+from . import time_utils
 
 
 def stack_by_init_date(ds, init_dates, n_lead_steps,
@@ -17,7 +17,7 @@ def stack_by_init_date(ds, init_dates, n_lead_steps,
     times = ds[time_dim]  
     init_dates = init_dates[np.logical_and(init_dates>=times.min(), init_dates<=times.max())]
     
-    # Initialise indices of specified inital dates and time info for each initial date
+    # Initialise indexes of specified inital dates and time info for each initial date
     time2d = np.empty((len(init_dates), n_lead_steps), 'object')
     time2d[:] = np.nan # Nans where data do not exist
     init_date_indexes = []

--- a/unseen/array_handling.py
+++ b/unseen/array_handling.py
@@ -11,7 +11,21 @@ from . import time_utils
 def stack_by_init_date(ds, init_dates, n_lead_steps,
                        time_dim='time', init_dim='init', lead_dim='lead'):
     """ Stack timeseries array in inital date / lead time format.
-        Adapted from https://github.com/AusClimateService/unseen/blob/master/unseen
+    
+        Args:
+          ds (xarray Dataset)
+          init_dates (list) : Initial dates in YYYY-MM-DD format
+          n_lead_steps (int) : Maximum lead time
+          time_dim (str) : The name of the time dimension on ds
+          init_dim (str) : The name of the initial date dimension on the output array
+          lead_dim (str) : The name of the lead time dimension on the output array
+
+        Note, only initial dates that fall within the time range of the input
+        timeseries are retained. Thus, inital dates prior to the time range of
+        the input timeseries that include data at longer lead times are not 
+        included in the output dataset. To include these data, prepend the input
+        timeseries with nans so that the initial dates in question are present
+        in the time dimension of the input timeseries.
     """
     # Only keep init dates that fall within available times
     times = ds[time_dim]  

--- a/unseen/tests/test_array_handling.py
+++ b/unseen/tests/test_array_handling.py
@@ -1,0 +1,99 @@
+import pytest
+
+import dask
+import dask.array as dsa
+
+import numpy as np
+import xarray as xr
+
+import numpy.testing as npt
+
+from unseen.array_handling import (
+    stack_by_init_date,
+)
+
+
+TIME_DIM = 'time'
+INIT_DIM = 'init'
+LEAD_DIM = 'lead'
+
+
+def empty_dask_array(shape, dtype=float, chunks=None):
+    """ A dask array that errors if you try to compute it
+        Stolen from https://github.com/xgcm/xhistogram/blob/master/xhistogram/test/fixtures.py
+    """
+    def raise_if_computed():
+        raise ValueError('Triggered forbidden computation on dask array')
+    a = dsa.from_delayed(dask.delayed(raise_if_computed)(), shape, dtype)
+    if chunks is not None:
+        a = a.rechunk(chunks)
+    return a
+
+
+@pytest.fixture()
+def example_da_timeseries(request):
+    """ An example timeseries DataArray """
+    time = xr.cftime_range(start='2000-01-01', end='2001-12-31', freq='D')
+    if request.param == 'dask':
+        data = empty_dask_array((len(time),))
+    else:
+        data = np.array([t.toordinal() for t in time])
+        data -= data[0]
+    return xr.DataArray(data, coords=[time], dims=[TIME_DIM])
+
+
+@pytest.mark.parametrize('example_da_timeseries', ['numpy'], indirect=True)
+@pytest.mark.parametrize('offset', [0, 10])
+@pytest.mark.parametrize('stride', [1, 10, 'irregular'])
+@pytest.mark.parametrize('n_lead_steps', [1, 10])
+def test_stack_by_init_date(example_da_timeseries, offset, stride, n_lead_steps):
+    """ Test values returned by stack_by_init_date """
+    def _np_stack_by_init_date(data, indexes, n_lead_steps):
+        """ Stack timeseries by index and n_lead_steps """
+        ver = np.empty((len(indexes), n_lead_steps))
+        ver[:] = np.nan
+        for i, idx in enumerate(indexes): 
+            time_slice = data[idx:idx+n_lead_steps]
+            ver[i, :len(time_slice)] = time_slice
+        return ver
+
+    data = example_da_timeseries
+
+    if stride == 'irregular':
+        indexes = np.concatenate((
+            [offset], np.random.randint(1, 20, size=1000))).cumsum()
+        indexes = indexes[indexes < data.sizes[TIME_DIM]]
+    else:
+        indexes = range(offset, data.sizes[TIME_DIM], stride)
+
+    init_dates = data[TIME_DIM][indexes]
+    res = stack_by_init_date(
+        data, init_dates, n_lead_steps, init_dim=INIT_DIM, lead_dim=LEAD_DIM)
+    ver = _np_stack_by_init_date(data, indexes, n_lead_steps)
+
+    # Check that values are correct
+    npt.assert_allclose(res, ver)
+
+    # Check that init dates are correct
+    npt.assert_allclose(xr.CFTimeIndex(init_dates.values).asi8, 
+                        res.get_index(INIT_DIM).asi8)
+
+    # Check that times at lead zero match the init dates 
+    npt.assert_allclose(xr.CFTimeIndex(init_dates.values).asi8, 
+                        xr.CFTimeIndex(res[TIME_DIM].isel({LEAD_DIM: 0}).values).asi8)
+    
+    
+@pytest.mark.parametrize('example_da_timeseries', ['dask'], indirect=True)
+def test_stack_by_init_date_dask(example_da_timeseries):
+    """ Test values returned by stack_by_init_date 
+    
+        For now just checks that doesn't trigger compute, but may want to add tests for
+        chunking etc in the future
+    """
+
+    data = example_da_timeseries
+    n_lead_steps = 10
+    init_dates = data[TIME_DIM][::10]
+    
+    res = stack_by_init_date(
+        data, init_dates, n_lead_steps, init_dim=INIT_DIM, lead_dim=LEAD_DIM)


### PR DESCRIPTION
This PR tries to fix a few bugs in `array_handling.stack_by_init_date` function. I have also changed the API of the function in the following ways:

- remove the `freq` parameter,
- expect that the `time` dimension of `ds` has the same dtype as `init_dates`. I think this is cleaner than requiring that `init_dates` is an array of strings,
- Add optional parameters for the names of the time, initial date and lead time dimensions.

I trialled adding a catch to use the `stride` option in `.rolling.contruct` when the initial dates are evenly spaced along the time dimension, but this ended up being overly complicated and didn't really add any performance benefits. 

I've added some basic tests of the new function and added `pytest` to `environment.yml` so that these tests can be run.

Closes #4