### PR TITLE
Simplify opening datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ Setup dask scheduling client:
 
 #### `fileio.py`
 Functions and command line program for file I/O:
-- `open_file`: create an xarray dataset from a single netCDF or zarr file, with many processing options (spatial/temporal selection and aggregation, unit conversion, etc)
-- `open_mfzarr`: open multiple zarr files
+- `open_dataset`: create an xarray dataset from one or more data files, with many processing options (spatial/temporal selection and aggregation, unit conversion, etc)
 - `open_mfforecast`: open multi-file forecast
 - `get_new_log`: generate command log for output file
 - `to_zarr`: write to zarr file

--- a/unseen/bias_correction.py
+++ b/unseen/bias_correction.py
@@ -121,10 +121,10 @@ def _main():
 
     args = _parse_command_line()
 
-    ds_obs = fileio.open_file(args.obs_file, variables=[args.var])
+    ds_obs = fileio.open_dataset(args.obs_file, variables=[args.var])
     da_obs = ds_obs[args.var]
 
-    ds_fcst = fileio.open_file(args.fcst_file, variables=[args.var])
+    ds_fcst = fileio.open_dataset(args.fcst_file, variables=[args.var])
     da_fcst = ds_fcst[args.var]
 
     bias = get_bias(da_fcst, da_obs, args.method, time_period=args.base_period)

--- a/unseen/independence.py
+++ b/unseen/independence.py
@@ -185,7 +185,7 @@ def _main():
         client = dask_setup.launch_client(args.dask_config)
         print(client)
 
-    ds_fcst = fileio.open_file(
+    ds_fcst = fileio.open_dataset(
         args.fcst_file, variables=[args.var], sel=args.spatial_selection
     )
     da_fcst = ds_fcst[args.var]

--- a/unseen/similarity.py
+++ b/unseen/similarity.py
@@ -87,9 +87,9 @@ def _main():
         client = dask_setup.launch_client(args.dask_config)
         print(client)
 
-    ds_fcst = fileio.open_file(args.fcst_file, variables=[args.var])
+    ds_fcst = fileio.open_dataset(args.fcst_file, variables=[args.var])
 
-    ds_obs = fileio.open_file(args.obs_file, variables=[args.var])
+    ds_obs = fileio.open_dataset(args.obs_file, variables=[args.var])
     if args.reference_time_period:
         time_slice = general_utils.date_pair_to_time_slice(args.reference_time_period)
         ds_obs = ds_obs.sel({"time": time_slice})


### PR DESCRIPTION
`engine=zarr` is now an option for `xr.open_dataset`, which I've used to simplify the `fileio` module.