### PR TITLE
Test for point selection

### DIFF
--- a/ci/environment-3.7.yml
+++ b/ci/environment-3.7.yml
@@ -3,6 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
+  - geopandas
+  - regionmask
   - xarray
   - dask-core
   - numpy

--- a/ci/environment-3.8.yml
+++ b/ci/environment-3.8.yml
@@ -3,6 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
+  - geopandas
+  - regionmask
   - xarray
   - dask-core
   - numpy

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -3,6 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
+  - geopandas
+  - regionmask
   - xarray
   - dask-core
   - numpy

--- a/unseen/spatial_selection.py
+++ b/unseen/spatial_selection.py
@@ -120,18 +120,19 @@ def select_box_region(ds, box):
 
     lon_east_bound = (lon_east_bound + 360) % 360
     lon_west_bound = (lon_west_bound + 360) % 360
-    assert 0 <= lon_east_bound < 360, "Valid longitude range is [0, 360)"
-    assert 0 <= lon_west_bound < 360, "Valid longitude range is [0, 360)"
+    assert 0 <= lon_east_bound <= 360, "Valid longitude range is [0, 360]"
+    assert 0 <= lon_west_bound <= 360, "Valid longitude range is [0, 360]"
 
     ds = ds.assign_coords({"lon": (ds["lon"] + 360) % 360})
+    ds = ds.sortby(ds["lon"])
 
-    mask_lat = (ds["lat"] > lat_south_bound) & (ds["lat"] < lat_north_bound)
+    selection_lat = (ds["lat"] >= lat_south_bound) & (ds["lat"] <= lat_north_bound)
     if lon_east_bound < lon_west_bound:
-        mask_lon = (ds["lon"] > lon_east_bound) & (ds["lon"] < lon_west_bound)
+        selection_lon = (ds["lon"] >= lon_east_bound) & (ds["lon"] <= lon_west_bound)
     else:
-        mask_lon = (ds["lon"] > lon_east_bound) | (ds["lon"] < lon_west_bound)
+        selection_lon = (ds["lon"] >= lon_east_bound) | (ds["lon"] <= lon_west_bound)
 
-    ds = ds.where(mask_lat & mask_lon, drop=True)
+    ds = ds.where(selection_lat & selection_lon, drop=True)
 
     return ds
 

--- a/unseen/spatial_selection.py
+++ b/unseen/spatial_selection.py
@@ -145,6 +145,7 @@ def select_point_region(ds, point):
     """
 
     ds = ds.assign_coords({"lon": (ds["lon"] + 360) % 360})
+    ds = ds.sortby(ds["lon"])
 
     lat, lon = point
     lon = (lon + 360) % 360

--- a/unseen/tests/conftest.py
+++ b/unseen/tests/conftest.py
@@ -11,6 +11,8 @@ def pytest_configure():
     pytest.TIME_DIM = "time"
     pytest.INIT_DIM = "init"
     pytest.LEAD_DIM = "lead"
+    pytest.LAT_DIM = "lat"
+    pytest.LON_DIM = "lon"
 
 
 def empty_dask_array(shape, dtype=float, chunks=None):
@@ -37,6 +39,17 @@ def example_da_timeseries(request):
         data = np.array([t.toordinal() for t in time])
         data -= data[0]
     return xr.DataArray(data, coords=[time], dims=[pytest.TIME_DIM])
+
+
+@pytest.fixture()
+def example_da_lon(request):
+    """An example DataArray of longitude values"""
+    maxlon = request.param
+    lats = np.arange(-90, 91)
+    lons = np.arange(maxlon - 360, maxlon)
+    data = np.tile((lons + 360) % 360, (len(lats), 1))
+    da = xr.DataArray(data, coords=[lats, lons], dims=[pytest.LAT_DIM, pytest.LON_DIM])
+    return da
 
 
 @pytest.fixture()

--- a/unseen/tests/test_spatial_selection.py
+++ b/unseen/tests/test_spatial_selection.py
@@ -1,8 +1,42 @@
 import pytest
 
 from unseen.spatial_selection import (
+    select_box_region,
     select_point_region,
 )
+
+
+@pytest.mark.parametrize("example_da_lon", [180, 360], indirect=True)
+@pytest.mark.parametrize(
+    "box",
+    [
+        [-45, 20, 60, 120],
+        [20, 30, 120, 60],
+        [-35, -15, -170, -120],
+        [0, 20, -120, -170],
+    ],
+)
+@pytest.mark.parametrize("data_object", ["DataArray", "Dataset"])
+def test_selected_box_lon(example_da_lon, box, data_object):
+    """Test longitudes of box returned by select_box_region."""
+    south_bound, north_bound, east_bound, west_bound = box
+    east_bound360 = (east_bound + 360) % 360
+    west_bound360 = (west_bound + 360) % 360
+
+    data = example_da_lon
+    if data_object == "Datatset":
+        data = data.to_dataset(name="var")
+
+    selection = select_box_region(data, box)
+
+    if east_bound360 < west_bound360:
+        assert selection.data.min() == east_bound360
+        assert selection.data.max() == west_bound360
+    else:
+        segment1_max = float(selection.where(selection < east_bound360).max().data)
+        segment2_min = float(selection.where(selection > west_bound360).min().data)
+        assert segment1_max == west_bound360
+        assert segment2_min == east_bound360
 
 
 @pytest.mark.parametrize("example_da_lon", [180, 360], indirect=True)

--- a/unseen/tests/test_spatial_selection.py
+++ b/unseen/tests/test_spatial_selection.py
@@ -1,0 +1,26 @@
+import pytest
+
+from unseen.spatial_selection import (
+    select_point_region,
+)
+
+
+@pytest.mark.parametrize("example_da_lon", [180, 360], indirect=True)
+@pytest.mark.parametrize("point", [[-55, 50], [60, -80]])
+@pytest.mark.parametrize("data_object", ["DataArray", "Dataset"])
+def test_selected_point_lon(example_da_lon, point, data_object):
+    """Test longitude of point returned by select_point_region."""
+    point_lat, point_lon = point
+    point_lon360 = (point_lon + 360) % 360
+
+    data = example_da_lon
+    if data_object == "Datatset":
+        data = data.to_dataset(name="var")
+
+    selection = select_point_region(data, point)
+    if data_object == "Datatset":
+        data_lon = float(selection["var"].values)
+    else:
+        data_lon = float(selection.values)
+
+    assert point_lon360 == data_lon


### PR DESCRIPTION
This PR adds a test to make sure the correct longitude is selected (when doing point selection) regardless of whether the input dataset or the requested longitude value uses -180 to 180 or 0 to 360.