### PR TITLE
Add xr.apply_ufunc wrapper to fit_gev 

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.11.0
     hooks:
     - id: black
       language_version: python3
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 6.1.0
     hooks:
     - id: flake8
       language_version: python3

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,23 +2,24 @@ name: unseen-test
 channels:
   - conda-forge
 dependencies:
-  - python
-  - geopandas
-  - regionmask
-  - xarray
-  - dask-core
-  - numpy
-  - pytest
   - cftime
-  - gitpython
   - cmdline_provenance
+  - dask-core
+  - dask-jobqueue
+  - geopandas
+  - gitpython
+  - netcdf4
+  - numpy
+  - pip
+  - pytest
+  - python
+  - regionmask
+  - scipy>=1.10.0
+  - seaborn
+  - xarray
   - xclim
   - xskillscore
-  - seaborn
   - zarr
-  - netcdf4
-  - dask-jobqueue
-  - pip
   - pip:
     - codecov
     - pytest-cov

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - scipy>=1.10.0
   - seaborn
   - xarray
-  - xclim
+  - xclim>=0.39.0
   - xskillscore
   - zarr
   - pip:

--- a/unseen/fileio.py
+++ b/unseen/fileio.py
@@ -244,7 +244,7 @@ def open_dataset(
         for var, target_units in units.items():
             ds[var] = general_utils.convert_units(ds[var], target_units)
 
-    assert type(ds) == xr.core.dataset.Dataset
+    assert isinstance(ds, xr.core.dataset.Dataset)
     ds = ds.squeeze(drop=True)
 
     return ds
@@ -495,7 +495,7 @@ def _guess_file_format(file_names):
 
     """
 
-    if type(file_names) == list:
+    if isinstance(file_names, list):
         file_name = file_names[0]
     else:
         file_name = file_names

--- a/unseen/general_utils.py
+++ b/unseen/general_utils.py
@@ -391,7 +391,6 @@ def fit_gev(
         if stationary:
             theta = shape, loc, scale
         else:
-
             # Initial parameter guesses.
             theta_i = -shape, loc, loc1, scale, scale1
 

--- a/unseen/general_utils.py
+++ b/unseen/general_utils.py
@@ -162,11 +162,12 @@ def check_gev_fit(data, theta, time_dim="time"):
     """
 
     def _goodness_of_fit(data, theta):
+        assert len(theta) in [3, 5]
         if len(theta) == 3:
             # Stationary parameters
             shape, loc, scale = theta
             test_data = data
-        else:
+        elif len(theta) == 5:
             # Non-stationary parameters (test middle 20% of data).
             # N.B. the non stationary parameters vary with the data distribution as a
             # function of the covariate, so we test a subset of data at a specific point.
@@ -193,10 +194,9 @@ def check_gev_fit(data, theta, time_dim="time"):
         data,
         theta,
         input_core_dims=[[time_dim], ["theta"]],
-        output_core_dims=[[]],
         vectorize=True,
-        dask="allowed",
-        dask_gufunc_kwargs=dict(output_dtypes="float64", meta=(float)),
+        dask="parallelized",
+        dask_gufunc_kwargs=dict(meta=(np.ndarray(1, float),)),
     )
     return pvalue
 
@@ -432,7 +432,7 @@ def fit_gev(
             input_core_dims=[[time_dim]],
             output_core_dims=[["theta"]],
             vectorize=True,
-            dask="allowed",
+            dask="parallelized",
             kwargs=kwargs,
             output_dtypes=["float64"],
             dask_gufunc_kwargs=dict(output_sizes={"theta": n}),

--- a/unseen/general_utils.py
+++ b/unseen/general_utils.py
@@ -5,7 +5,7 @@ import re
 
 import numpy as np
 from scipy.optimize import minimize
-from scipy.stats import rv_continuous, genextreme, goodness_of_fit
+from scipy.stats import genextreme, goodness_of_fit
 from xarray import apply_ufunc
 import xclim
 
@@ -140,13 +140,28 @@ def event_in_context(data, threshold, direction):
     return n_events, n_population, return_period, percentile
 
 
-class ns_genextreme_gen(rv_continuous):
-    """Extreme value distributions (stationary or non-stationary)."""
+def check_gev_fit(data, theta, time_dim="time"):
+    """Test distribution goodness of fit
 
-    def _check_fit(self, theta, **kwargs):
-        """Test goodness of fit and (if applicable) retry fit by generating an initial estimate."""
-        data = kwargs.pop("data")
+    Parameters
+    ----------
+    data, x: array-like
+        Data and covariate to fit.
+    theta : tuple of floats
+        Shape, location and scale parameters (shape, loc0, loc1, scale0, scale1).
 
+    Returns
+    -------
+    pvalue : scipy.stats._fit.GoodnessOfFitResult.pvalue
+        Goodness of fit pvalue.
+
+    Notes
+    -----
+    - For non-stationary distributions, the fit is compared to a subset
+    of data near the middle of the timeseries.
+    """
+
+    def _goodness_of_fit(data, theta):
         if len(theta) == 3:
             # Stationary parameters
             shape, loc, scale = theta
@@ -160,7 +175,7 @@ class ns_genextreme_gen(rv_continuous):
             dt = n // 10  # 10% of datapoints to test for goodness of fit.
 
             # Subset data around midpoint.
-            test_data = data.isel({data.dims[-1]: slice(max(0, t - dt), t + dt)})
+            test_data = data[t - dt : t + dt]
 
             shape, loc, loc1, scale, scale1 = theta
             loc = loc + loc1 * t
@@ -169,20 +184,98 @@ class ns_genextreme_gen(rv_continuous):
         res = goodness_of_fit(
             genextreme, test_data, known_params=dict(c=shape, loc=loc, scale=scale)
         )
+        return res.pvalue
 
-        # Accept the null distribution of the AD test.
-        success = True if res.pvalue > 0.01 else False
-        if not success:
-            if not kwargs["generate_estimates"]:
-                print("Data fit failed. Retrying with 'generate_estimates=True'.")
-                kwargs["generate_estimates"] = True
-                theta = self.fit(data, **kwargs)
-            else:
-                print("Data fit failed.")
-        return theta
+    pvalue = apply_ufunc(
+        _goodness_of_fit,
+        data,
+        theta,
+        input_core_dims=[[time_dim], ["theta"]],
+        output_core_dims=[[]],
+        vectorize=True,
+        dask="parallelized",
+        dask_gufunc_kwargs=dict(
+            output_dtypes=["float64"]  # , output_sizes={"pvalue": 1}
+        ),
+    )
+    return pvalue
 
-    def fit_stationary(self, data, user_estimates, generate_estimates):
-        """Return estimates of shape, location and scale parameters using genextreme."""
+
+def fit_gev(
+    data,
+    user_estimates=None,
+    loc1=0,
+    scale1=0,
+    x=None,
+    time_dim="time",
+    stationary=True,
+    check_fit=False,
+    generate_estimates=False,
+    method="Nelder-Mead",
+):
+    """Estimate parameters for stationary or non-stationary data distributions.
+
+    Parameters
+    ----------
+    data : xarray.dataArray
+        Data to fit.
+    user estimates: list, default None
+        Initial estimates of the shape, loc and scale parameters
+    loc1, scale1 : float, default 0
+        Initial estimates of the location and scale trend parameters
+    x : array-like, default None (assumes linear)
+        A non-stationary covariate (e.g., x=np.arange(data.time.size)).
+    time_dim : str, default 'time'
+        Name of time dimension in 'data'.
+    stationary : bool, default True
+        Fit as a stationary GEV using scipy.stats.genextremes.fit
+    check_fit : bool, default False
+        Test goodness of fit and attempt retry
+    generate_estimates : bool, default False
+        Generate initial parameter guesses using a data subset.
+    method : str, default 'Nelder-Mead'
+        Method used for scipy.optimize.minimize
+
+    Returns
+    -------
+    theta : tuple
+        Shape, location and scale parameters (and loc1, scale1 if applicable)
+
+    Notes
+    -----
+    - For stationary data the shape, location and scale parameters are
+    estimated using scipy.stats.genextremes.fit().
+    - For non-stationary data, the linear location and scale trend
+    parameters are estimated using a penalised negative log-likelihood
+    function with initial estimates based on the stationary fit.
+    - The distribution fit is considered 'good' if the p-value is above
+    the 99th percent level (i.e.,  accept the null hypothesis).
+    - If the parameters fail the goodness of fit test, it will attempt
+    to fit the data again by generating an initial guess - if that
+    hasn't already been tried.
+
+    Example
+    -------
+    '''
+    import xarray as xr
+    n = 1000
+    m = 1e-3
+    x = np.arange(n)
+    rvs = genextreme.rvs(-0.05, loc=3.2, scale=0.5, size=n, random_state=0)
+    data = xr.DataArray(rvs + x * m, coords={'time': x})
+    data.plot()
+
+    shape, loc, scale = fit_gev(data, stationary=True)
+    shape, loc, loc1, scale, scale1 = fit_gev(data, stationary=False)
+
+    data_2d = xr.concat([data, data + x * 1e-2], 'lat')
+    theta = fit_gev(data_2d, stationary=False, check_fit=True)
+    '''
+    """
+    kwargs = locals()  # Function inputs
+
+    def fit_stationary_gev(data, user_estimates, generate_estimates):
+        """Estimate stationary shape, location and scale parameters."""
         if user_estimates:
             shape, loc, scale = user_estimates
             shape, loc, scale = genextreme.fit(data, shape, loc=loc, scale=scale)
@@ -195,40 +288,52 @@ class ns_genextreme_gen(rv_continuous):
             shape, loc, scale = genextreme.fit(data)
         return shape, loc, scale
 
-    def _sum_finite(self, x):
-        """Sum finite values and count the number of nonfinite values in a 1D array.
+    def penalised_sum(x):
+        """Sum finite values in a 1D array and add nonfinite penalties.
 
         This is a utility function used when evaluating the negative
-        loglikelihood for a distribution and an array of samples. Stolen from
+        loglikelihood for a distribution and an array of samples.
+        Adapted/stolen from:
         https://github.com/scipy/scipy/blob/v1.11.3/scipy/stats/_distn_infrastructure.py
         """
         finite_x = np.isfinite(x)
         bad_count = finite_x.size - np.count_nonzero(finite_x)
-        return np.sum(x[finite_x]), bad_count
 
-    def nllf(self, theta, data, x):
-        """Penalised negative log-likelihood of GEV probability density function.
+        total = np.sum(x[finite_x])
+        penalty = bad_count * np.log(np.finfo(float).max) * 100
 
-        A modified version of scipy.stats.genextremes.fit for fitting extreme value
-        distribution parameters, in which the location and scale parameters can vary
-        linearly with a covariate.
-        A large, finite penalty (rather than infinite negative log-likelihood)
-        is applied for observations beyond the support of the distribution.
-        Suitable for stationary or non stationary distributions. The non-stationary
-        parameters are returned if the input 'theta' incudes the varying
-        location and scale parameters.
+        return total + penalty
+
+    def nllf(theta, data, x):
+        """Penalised negative log-likelihood function.
 
         Parameters
         ----------
         theta : tuple of floats
-            Shape, location and scale parameters (shape, loc0, loc1, scale0, scale1).
+            Distribution parameters (can be stationary or non-stationary)
+            or
         data, x: array-like
-            Data and covariate to fit.
+            Data to fit and covariate (e.g., timesteps).
 
         Returns
         -------
         total : float
-            The penalised negative likelihood function summed over all values of x.
+            The penalised NLLF summed over all values of x.
+
+        Notes
+        -----
+        - A modified version of scipy.stats.genextremes.fit for fitting
+        extreme value distribution parameters, in which the location and
+        scale parameters can vary linearly with a covariate.
+        - Suitable for stationary or non-stationary distributions:
+            - theta = (shape, loc, scale)
+            - theta = (shape, loc, loc1, scale, scale1)
+        - The non-stationary parameters are returned if the input theta
+        incudes the varying location and scale parameters.
+        - A large finite penalty (instead of infinity) is applied for
+        observations beyond the support of the distribution.
+        - The NLLF is not finite when the shape is nonzero and Z is
+        negative because the PDF is zero (i.e., log(0)=inf)).
         """
         if len(theta) == 5:
             # Non-stationary GEV parameters.
@@ -248,9 +353,7 @@ class ns_genextreme_gen(rv_continuous):
 
         else:
             Z = 1 + shape * s
-            # NLLF at points where the data is supported by the distribution parameters.
-            # (N.B. the NLLF is not finite when the shape is nonzero and Z is negative
-            # because the PDF is zero (log(0)=inf) outside of these bounds).
+            # NLLF where data is supported by the parameters (see notes).
             f = np.where(
                 Z > 0,
                 np.log(scale)
@@ -261,114 +364,55 @@ class ns_genextreme_gen(rv_continuous):
 
         f = np.where(scale > 0, f, np.inf)  # Scale parameter must be positive.
 
-        # Sum function along all axes (where finite) & count infinite elements.
-        total, n_bad = self._sum_finite(f)
-
-        # Add large finite penalty instead of infinity (log of the largest useable float).
-        total = total + n_bad * np.log(np.finfo(float).max) * 100
+        # Sum function along all axes (where finite) & add penalty for each infinite element.
+        total = penalised_sum(f)
         return total
 
     def _fit(
-        self,
         data,
-        user_estimates=None,
-        loc1=0,
-        scale1=0,
-        x=None,
-        generate_estimates=False,
-        stationary=True,
-        check_fit=False,
-        method="Nelder-Mead",
+        user_estimates,
+        loc1,
+        scale1,
+        x,
+        time_dim,
+        generate_estimates,
+        stationary,
+        check_fit,
+        method,
     ):
-        """Return estimates of data distribution parameters.
-
-        For stationary data, estimates the shape, location and scale parameters using
-        scipy.stats.genextremes.fit(). For non-stationary data, also estimates the linear
-        location and scale trend parameters using a penalised negative log-likelihood
-        function with initial estimates based on the stationary fit.
-
-        Parameters
-        ----------
-        data : xarray.dataArray
-            Data as a function of a covariate (assumed to be on axis=-1).
-        user estimates: list, default None
-            Initial estimates of the shape, loc and scale parameters
-        loc1, scale1 : float, default 0
-            Initial estimates of the location and scale trend parameters
-        x : array-like, default None (i.e., linear)
-            The covariate (e.g., timesteps)
-        stationary : bool, default True
-            Fit as a stationary GEV using scipy.stats.genextremes.fit
-        check_fit : bool, default False
-            Test goodness of fit and attempt retry
-        method : str, default 'Nelder-Mead'
-            Method used for scipy.optimize.minimize
-
-        Returns
-        -------
-        theta : tuple of floats
-            Shape, location and scale parameters (and loc1, scale1 if applicable)
-
-        Example
-        -------
-        '''
-        n = 1000
-        m = 1e-3
-        x = np.arange(n)
-        rvs = genextreme.rvs(-0.05, loc=3.2, scale=0.5, size=n, random_state=0)
-        data = xr.DataArray(rvs + x * m, coords={'time': x})
-        data.plot()
-
-        fit_gev = ns_genextreme_gen().fit
-        shape, loc, scale = fit_gev(data, stationary=True)
-        shape, loc, loc1, scale, scale1 = fit_gev(data, stationary=False)
-
-        data_2d = xr.concat([data, data + x * 1e-2], 'lat')
-        theta = fit_gev(data_2d, stationary=False)
-        print(theta.dims)
-        ('lat', 'theta')
-        '''
-        """
-        kwargs = locals()
+        """Estimate distribution parameters."""
 
         # Use genextremes to get stationary distribution parameters.
-        shape, loc, scale = self.fit_stationary(
-            data, user_estimates, generate_estimates
-        )
+        shape, loc, scale = fit_stationary_gev(data, user_estimates, generate_estimates)
 
         if stationary:
             theta = shape, loc, scale
         else:
-            if x is None:
-                x = np.arange(data.shape[-1], dtype=int)
+
+            # Initial parameter guesses.
             theta_i = -shape, loc, loc1, scale, scale1
 
             # Optimisation bounds (scale parameter must be non-negative).
             bounds = [(None, None), (None, None), (None, None), (0, None), (None, None)]
 
             # Minimise the negative log-likelihood function to get optimal theta.
-            res = minimize(
-                self.nllf, theta_i, args=(data, x), method=method, bounds=bounds
-            )
+            res = minimize(nllf, theta_i, args=(data, x), method=method, bounds=bounds)
             theta = res.x
 
-            # Flip sign of shape for consistency with scipy.stats results.
+            # Restore 'shape' sign for consistency with scipy.stats results.
             theta[0] *= -1
-
-        if check_fit:
-            kwargs.pop("self")
-            theta = self._check_fit(theta, **kwargs)
         return np.array(theta)
 
-    def fit(self, data, **kwargs):
-        """xarray.apply_ufunc wrapper for ns_genextreme_gen._fit."""
-        time_dim = data.dims[-1]  # Assumes the time/covariate is on the last axis.
+    def fit(data, **kwargs):
+        """xarray.apply_ufunc wrapper for _fit."""
+        stationary = kwargs["stationary"]
+        time_dim = kwargs["time_dim"]
 
         # Expected output of theta (3 parameters unless stationary=False is specified).
-        n = 3 if kwargs.get("stationary", True) else 5
+        n = 3 if stationary else 5
 
         theta = apply_ufunc(
-            self._fit,
+            _fit,
             data,
             input_core_dims=[[time_dim]],
             output_core_dims=[["theta"]],
@@ -379,14 +423,34 @@ class ns_genextreme_gen(rv_continuous):
                 output_dtypes=["float64"], output_sizes={"theta": n}
             ),
         )
-
-        if len(data.shape) == 1:
-            # If input is a 1D array, return a tuple of scalars instead of a data array.
-            theta = tuple([i.item() for i in theta])
         return theta
 
+    data = kwargs.pop("data")
 
-fit_gev = ns_genextreme_gen().fit
+    # Create covariate array (assuming linear timesteps).
+    if x is None:
+        time_axis = data.dims.index(time_dim)
+        kwargs["x"] = np.arange(data.shape[time_axis], dtype=int)  # core dim
+
+    theta = fit(data, **kwargs)
+
+    if check_fit:
+        pvalue = check_gev_fit(data, theta)
+
+        # Accept the null distribution of the AD test.
+        success = True if pvalue > 0.01 else False  # !!!
+        if not success:
+            if not kwargs["generate_estimates"]:
+                print("Data fit failed. Retrying with 'generate_estimates=True'.")
+                kwargs["generate_estimates"] = True  # Also breaks loop
+                theta = fit(data, **kwargs)
+            else:
+                print("Data fit failed.")
+
+    # Return a tuple of scalars instead of a 1D data array
+    if len(data.shape) == 1:
+        theta = tuple([i.item() for i in theta])
+    return theta
 
 
 def return_period(data, event, **kwargs):

--- a/unseen/general_utils.py
+++ b/unseen/general_utils.py
@@ -182,7 +182,9 @@ def check_gev_fit(data, theta, time_dim="time"):
             scale = scale + scale1 * t
 
         res = goodness_of_fit(
-            genextreme, test_data, known_params=dict(c=shape, loc=loc, scale=scale)
+            genextreme,
+            test_data,
+            known_params=dict(c=shape, loc=loc, scale=scale),
         )
         return res.pvalue
 
@@ -394,14 +396,27 @@ def fit_gev(
             theta_i = -shape, loc, loc1, scale, scale1
 
             # Optimisation bounds (scale parameter must be non-negative).
-            bounds = [(None, None), (None, None), (None, None), (0, None), (None, None)]
+            bounds = [
+                (None, None),
+                (None, None),
+                (None, None),
+                (0, None),
+                (None, None),
+            ]
 
             # Minimise the negative log-likelihood function to get optimal theta.
-            res = minimize(nllf, theta_i, args=(data, x), method=method, bounds=bounds)
+            res = minimize(
+                nllf,
+                theta_i,
+                args=(data, x),
+                method=method,
+                bounds=bounds,
+            )
             theta = res.x
 
             # Restore 'shape' sign for consistency with scipy.stats results.
             theta[0] *= -1
+        theta = np.array([i for i in theta], dtype="float64")
         return theta
 
     def fit(data, **kwargs):
@@ -450,7 +465,7 @@ def fit_gev(
 
     # Return a tuple of scalars instead of a 1D data array
     if len(data.shape) == 1:
-        theta = tuple([i.item() for i in theta])
+        theta = np.array([i for i in theta], dtype="float64")
     return theta
 
 
@@ -597,7 +612,10 @@ def plot_gev_return_curve(
     ) = event_data
 
     ax.plot(
-        curve_return_periods, curve_values, color="tab:blue", label="GEV fit to data"
+        curve_return_periods,
+        curve_values,
+        color="tab:blue",
+        label="GEV fit to data",
     )
     ax.fill_between(
         curve_return_periods,

--- a/unseen/spatial_selection.py
+++ b/unseen/spatial_selection.py
@@ -393,7 +393,7 @@ def _nan_to_bool(mask):
         Data array of True (where floats were) and False (where NaNs were) values
     """
 
-    assert type(mask) == xr.core.dataarray.DataArray
+    assert isinstance(mask, xr.core.dataarray.DataArray)
     if mask.values.dtype != "bool":
         mask = xr.where(mask.notnull(), True, False)
 

--- a/unseen/tests/test_eva.py
+++ b/unseen/tests/test_eva.py
@@ -13,7 +13,9 @@ np.random.seed(1)
 
 def example_da_gev_1d():
     """An example 1D GEV DataArray and its distribution parameters."""
-    time = np.arange("2000-01-01", "2005-01-01", dtype=np.datetime64)
+    time = np.arange(
+        "2000-01-01", "2005-01-01", np.timedelta64(1, "D"), dtype="datetime64[ns]"
+    )
 
     # Generate shape, location and scale parameters.
     shape = np.random.uniform()
@@ -35,7 +37,9 @@ def example_da_gev_1d_dask():
 
 def example_da_gev_3d():
     """An example 3D GEV DataArray and its distribution parameters."""
-    time = np.arange("2000-01-01", "2005-01-01", dtype=np.datetime64)
+    time = np.arange(
+        "2000-01-01", "2005-01-01", np.timedelta64(1, "D"), dtype="datetime64[ns]"
+    )
     lats = np.arange(0, 2)
     lons = np.arange(0, 2)
     shape = (len(lats), len(lons))

--- a/unseen/tests/test_eva.py
+++ b/unseen/tests/test_eva.py
@@ -1,0 +1,81 @@
+import pytest
+
+import numpy as np
+import xarray as xr
+
+import numpy.testing as npt
+from scipy.stats import genextreme
+
+from unseen.general_utils import fit_gev, check_gev_fit
+
+rtol = 0.25  # relative tolerance
+
+def example_da_gev_1d():
+    """An example 1D timeseries DataArray"""
+    time = np.arange("2000-01-01", "2002-01-01", dtype=np.datetime64)
+
+    c = np.random.rand()
+    loc = np.random.randint(-10, 10) + np.random.rand()
+    scale = np.random.rand()
+    theta = c, loc, scale
+
+    rvs = genextreme.rvs(c, loc=loc, scale=scale, size=(time.size), random_state=0)
+    data = xr.DataArray(rvs, coords=[time], dims=['time'])
+    return data, theta
+
+
+def example_da_gev_1d_dask():
+    data, theta = example_da_gev_1d()
+    data = data.chunk()
+    return data, theta
+
+
+def example_da_gev_3d():
+    """An example multi-dim timeseries DataArray"""
+    time = np.arange("2000-01-01", "2002-01-01", dtype=np.datetime64)
+    lats = np.arange(0, 2)
+    lons = np.arange(0, 2)
+    shape = (len(lats), len(lons))
+
+    c = np.random.rand(*shape)
+    loc = np.random.rand(*shape) + np.random.randint(-10, 10, shape)
+    scale = np.random.rand(*shape)
+    theta = np.stack([c, loc, scale], axis=-1)
+
+    rvs = genextreme.rvs(c, loc=loc, scale=scale, size=(time.size, *shape), random_state=0)
+    data = xr.DataArray(rvs, coords=[time, lats, lons], dims=['time', 'lat', 'lon'])
+    return data, theta
+
+
+def example_da_gev_3d_dask():
+    data, theta = example_da_gev_3d()
+    data = data.chunk()
+    return data, theta
+
+
+def test_fit_gev_1d():
+    # 1D data matches given parameters.
+    data, theta_i = example_da_gev_1d()
+    theta = fit_gev(data, stationary=True, check_fit=False)
+    npt.assert_allclose(theta, theta_i, rtol=rtol)
+
+
+def test_fit_gev_1d_dask():
+    # 1D chunked data matches given parameters.
+    data, theta_i = example_da_gev_1d_dask()
+    theta = fit_gev(data, stationary=True, check_fit=False)
+    npt.assert_allclose(theta, theta_i, rtol=rtol)
+
+
+def test_fit_gev_3d():
+    # 3D data matches given parameters.
+    data, theta_i = example_da_gev_3d()
+    theta = fit_gev(data, stationary=True, check_fit=True)
+    npt.assert_allclose(theta, theta_i, rtol=rtol)
+
+
+def test_fit_gev_3d_dask():
+    # 3D chunked data matches given parameters.
+    data, theta_i = example_da_gev_3d_dask()
+    theta = fit_gev(data, stationary=True, check_fit=True)
+    npt.assert_allclose(theta, theta_i, rtol=rtol)

--- a/unseen/tests/test_eva.py
+++ b/unseen/tests/test_eva.py
@@ -8,16 +8,16 @@ from unseen.general_utils import fit_gev, check_gev_fit
 
 rtol = 0.3  # relative tolerance
 alpha = 0.05
-np.random.seed(1)
 
 
 def example_da_gev_1d():
     """An example 1D GEV DataArray and its distribution parameters."""
     time = np.arange(
-        "2000-01-01", "2005-01-01", np.timedelta64(1, "D"), dtype="datetime64[ns]"
+        "2000-01-01", "2003-01-01", np.timedelta64(1, "D"), dtype="datetime64[ns]"
     )
 
     # Generate shape, location and scale parameters.
+    np.random.seed(0)
     shape = np.random.uniform()
     loc = np.random.uniform(-10, 10)
     scale = np.random.uniform(0.1, 10)
@@ -38,12 +38,13 @@ def example_da_gev_1d_dask():
 def example_da_gev_3d():
     """An example 3D GEV DataArray and its distribution parameters."""
     time = np.arange(
-        "2000-01-01", "2005-01-01", np.timedelta64(1, "D"), dtype="datetime64[ns]"
+        "2000-01-01", "2003-01-01", np.timedelta64(1, "D"), dtype="datetime64[ns]"
     )
     lats = np.arange(0, 2)
     lons = np.arange(0, 2)
     shape = (len(lats), len(lons))
 
+    np.random.seed(0)
     c = np.random.rand(*shape)
     loc = np.random.rand(*shape) + np.random.randint(-10, 10, shape)
     scale = np.random.rand(*shape)
@@ -71,10 +72,6 @@ def add_example_gev_trend(data):
     trend = np.arange(data.time.size) / data.time.size
     trend = xr.DataArray(trend, coords={"time": data.time})
     return data + trend
-
-
-data, theta_i = example_da_gev_3d()
-theta = fit_gev(data, stationary=True, check_fit=False)
 
 
 def test_fit_gev_1d():
@@ -110,7 +107,7 @@ def test_fit_gev_3d_dask():
 
 
 def test_fit_ns_gev_1d():
-    """Run stationary fit using 1D array & check results."""
+    """Run non-stationary fit using 1D array & check results."""
     data, _ = example_da_gev_1d()
     data = add_example_gev_trend(data)
 
@@ -124,7 +121,7 @@ def test_fit_ns_gev_1d():
 
 
 def test_fit_ns_gev_1d_dask():
-    """Run stationary fit using 1D dask array & check results."""
+    """Run non-stationary fit using 1D dask array & check results."""
     data, _ = example_da_gev_1d_dask()
 
     # Add a positive linear trend.
@@ -138,7 +135,7 @@ def test_fit_ns_gev_1d_dask():
 
 
 def test_fit_ns_gev_3d():
-    """Run stationary fit using 3D array & check results."""
+    """Run non-stationary fit using 3D array & check results."""
     data, _ = example_da_gev_3d()
 
     # Add a positive linear trend.
@@ -152,7 +149,7 @@ def test_fit_ns_gev_3d():
 
 
 def test_fit_ns_gev_3d_dask():
-    """Run stationary fit using 3D dask array & check results."""
+    """Run non-stationary fit using 3D dask array & check results."""
     data, _ = example_da_gev_3d_dask()
 
     # Add a positive linear trend.


### PR DESCRIPTION
The `fit_gev` function is now wrapped with `xr.apply_ufunc`, so fitting data to a distribution (normal or non-stationary version) should work for multi-dim input. 

If the input data is a 1D timerseries, the output will just be the expected values of the parameters:
```
shape, loc, scale = fit_gev(data)
```
Otherwise, the output will be a data array:
```
theta = fit_gev(data)
shape, loc, scale = theta.isel(lat=0, lon=0).values
```

The function assumes that the input data has time on the last axis (e.g., dims=(ensemble, lat, lon, time)) and infers the dimension name from that. However, I'm not sure if that is a common way of ordering dimensions. 

Do you think it will be better to have a `time_dim='time'` input argument and infer the axis position from that or something?

Also, the overall function setup probably isn't great and it might be hard to find the actual docstring:
```
fit_gev = ns_genextreme_gen().fit
```
where `ns_genextreme_gen().fit` is just a wrapper for the actual fitting function,`ns_genextreme_gen()._fit`.

@DamienIrving and @dougiesquire any suggestions for improvements?

