### PR TITLE
Update time aggregation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash -l {0}
         run: python -m pytest unseen
 
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v1
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
         with:
-          file: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/unseen/fileio.py
+++ b/unseen/fileio.py
@@ -103,8 +103,9 @@ def open_dataset(
         Remove leap days from data
     rolling_sum_window : int, default None
         Apply a rolling sum with this window width
-    time_freq : {'A-DEC', 'M', 'Q-NOV', 'A-NOV', 'A-AUG', 'A-JUN'}, optional
+    time_freq : str, optional
         Target temporal frequency for resampling
+        Options: https://pandas.pydata.org/docs/user_guide/timeseries.html#anchored-offsets
     time_agg : {'mean', 'sum', 'min', 'max'}, optional
         Temporal aggregation method
     time_agg_dates : bool, default False
@@ -119,7 +120,7 @@ def open_dataset(
         Shift time values after resampling so months match initial date
     time_agg_min_tsteps : int, optional
         Minimum number of timesteps for temporal aggregation
-    input_freq : {'A', 'Q', 'M', 'D'}, optional
+    input_freq : {'Y', 'Q', 'M', 'D'}, optional
         Input time frequency for resampling (estimated if not provided)
     time_dim: str, default 'time'
         Name of the time dimension in infiles
@@ -610,7 +611,6 @@ def _parse_command_line():
     parser.add_argument(
         "--time_freq",
         type=str,
-        choices=("A-DEC", "M", "Q-NOV", "A-NOV", "A-AUG", "A-JUN"),
         default=None,
         help="Target frequency for temporal aggregation",
     )
@@ -656,7 +656,7 @@ def _parse_command_line():
     parser.add_argument(
         "--input_freq",
         type=str,
-        choices=("M", "D", "Q", "A"),
+        choices=("M", "D", "Q", "Y"),
         default=None,
         help="Time frequency of input data",
     )

--- a/unseen/time_utils.py
+++ b/unseen/time_utils.py
@@ -70,14 +70,15 @@ def temporal_aggregation(
     Parameters
     ----------
     ds : xarray Dataset
-    target_freq : {'A-DEC', 'Q-NOV', 'M', 'A-NOV', 'A-AUG', 'A-JUN'}
+    target_freq : str
         Target frequency for the resampling
+        Options: https://pandas.pydata.org/docs/user_guide/timeseries.html#anchored-offsets
     agg_method : {'mean', 'min', 'max', 'sum'}
         Aggregation method
     variables : list
         Variables in the dataset
-    input_freq : {'D', 'M', 'Q', 'A'}
-        Temporal frequency of input data (daily, monthly or annual)
+    input_freq : {'D', 'M', 'Q', 'Y'}
+        Temporal frequency of input data (daily, monthly, quarterly or yearly)
     season : {'DJF', 'MAM', 'JJA', 'SON'}, optional
         Select a single season after Q-NOV resampling
     reset_times : bool, default False
@@ -96,16 +97,16 @@ def temporal_aggregation(
 
     Notes
     -----
-    A-DEC = annual, with date label being last day of year
-    M = monthly, with date label being last day of month
-    Q-NOV = DJF, MAM, JJA, SON, with date label being last day of season
-    A-NOV = annual Dec-Nov, date label being last day of the year
-    A-AUG = annual Sep-Aug, date label being last day of the year
-    A-JUN = annual Jul-Jun, date label being last day of the year
+    Example target_freq includes:
+      YE-DEC = annual, with date label being last day of year
+      M = monthly, with date label being last day of month
+      Q-NOV = DJF, MAM, JJA, SON, with date label being last day of season
+      YE-NOV = annual Dec-Nov, date label being last day of the year
+      YE-AUG = annual Sep-Aug, date label being last day of the year
+      YE-JUN = annual Jul-Jun, date label being last day of the year
     """
 
-    assert target_freq in ["A-DEC", "M", "Q-NOV", "A-NOV", "A-AUG", "A-JUN"]
-    assert input_freq in ["D", "M", "Q", "A"]
+    assert input_freq in ["D", "M", "Q", "Y"]
 
     if time_dim not in ds.dims:
         ds = array_handling.reindex_forecast(ds)


### PR DESCRIPTION
Updates include:
- Allow the use of any [pandas anchored offset](https://pandas.pydata.org/pandas-docs/version/1.4.1/user_guide/timeseries.html#anchored-offsets) for time aggregation.
- Change from `A` to `YE` for annual time aggregation to accommodate changes to the latest versions of pandas.